### PR TITLE
Ensure login for 'register' page

### DIFF
--- a/one_big_thing/learning/views.py
+++ b/one_big_thing/learning/views.py
@@ -469,9 +469,13 @@ def additional_learning_view(request):
     return render(request, "additional-learning.html", {"data": data})
 
 
+# Need login otherwise can't save against unknown user
+# This happens before pre_survey
+@login_required
+@require_http_methods(["POST", "GET"])
 class RegisterView(utils.MethodDispatcher):
     template_name = "register.html"
-    error_message = "Something has gone wrong.  Please try again."
+    error_message = "Something has gone wrong. Please try again."
 
     def error(self, request):
         messages.error(request, self.error_message)


### PR DESCRIPTION
This fixes error: https://i-dot-ai.sentry.io/issues/4432189136/?project=4505588973895680&query=is%3Aunresolved&referrer=issue-stream&stream_index=2

Error came about as could access the `register` page without being logged in, so there was an anonymous user that couldn't be saved.

I think there is more that needs to be done to improve this - need to enforce filling in details on grade, profession etc. (this was the case before registration was changed), probably good to refactor and rename (as it's no longer a "registration" page). But that is beyond the scope of this PR.