### PR TITLE
Bugfix/actually ignore errors

### DIFF
--- a/one_big_thing/settings.py
+++ b/one_big_thing/settings.py
@@ -199,7 +199,8 @@ def before_send(event, hint):
         "Invalid HTTP_HOST header",  # Scrapers and bots
         "Slow DB Query",  # 10DS data query
     ]
-    if event.get("message") in messages_to_ignore:
+    event_message = event.get("message")
+    if any(event_message.startswith(prefix) for prefix in messages_to_ignore):
         return None
     return event
 

--- a/one_big_thing/settings.py
+++ b/one_big_thing/settings.py
@@ -215,7 +215,7 @@ if not DEBUG:
         ],
         environment=ENVIRONMENT,
         send_default_pii=False,
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.2,
         profiles_sample_rate=0.0,
         before_send=before_send,
     )


### PR DESCRIPTION
Hopefully actually ignore errors this time - looks like we're still getting them in Sentry.

Change the "traces sample rate" to get 20% of errors - this means that we won't burn through our errors quota if the issue isn't fixed (can change back once we're convinced that it's sorted). We're getting so many "Invalid auth headers" errors that even 20% of them will show up fast.

Tested the invalid host header by setting local vars `DEBUG=False`, `SENTRY_DSN` to the Sentry key. Ran `curl -v -k -H "Host: 169.254.100.100" "http://localhost:8055/"` to create the error locally. This appeared in Sentry before changes to settings file, didn't get error after changes to ignore errors (hadn't made the changes to traces sample rate for testing).