### PR TITLE
Feature/10ds-api-v2

### DIFF
--- a/one_big_thing/api_serializers.py
+++ b/one_big_thing/api_serializers.py
@@ -36,4 +36,11 @@ class DepartmentBreakdownSerializer(serializers.Serializer):
     completed_7_plus_hours_of_learning = serializers.IntegerField()
 
     class Meta:
-        fields = ["__all__"]
+        fields = "__all__"
+
+
+class DepartmentBreakdownV2Serializer(DepartmentBreakdownSerializer):
+    completed_0_hours_of_learning = serializers.IntegerField()
+
+    class Meta:
+        fields = "__all__"

--- a/one_big_thing/learning/api_views.py
+++ b/one_big_thing/learning/api_views.py
@@ -220,7 +220,7 @@ LEFT JOIN (
     SELECT
     user_id,
     CASE
-        WHEN hours_learning >= 0  THEN 1
+        WHEN hours_learning > 0  THEN 1
         ELSE 0
         END as completed_0_hours_of_learning,
     CASE

--- a/one_big_thing/urls.py
+++ b/one_big_thing/urls.py
@@ -11,7 +11,8 @@ from one_big_thing.learning.admin import admin_site
 from one_big_thing.learning.api_views import (
     JwtTokenObtainPairView,
     UserSignupStatsView,
-    UserStatisticsView, UserStatisticsV2View,
+    UserStatisticsV2View,
+    UserStatisticsView,
 )
 
 api_urlpatterns = [

--- a/one_big_thing/urls.py
+++ b/one_big_thing/urls.py
@@ -11,13 +11,14 @@ from one_big_thing.learning.admin import admin_site
 from one_big_thing.learning.api_views import (
     JwtTokenObtainPairView,
     UserSignupStatsView,
-    UserStatisticsView,
+    UserStatisticsView, UserStatisticsV2View,
 )
 
 api_urlpatterns = [
     path("api/token/", JwtTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/user-statistics/", UserStatisticsView.as_view(), name="user_statistics"),
+    path("api/v2/user-statistics/", UserStatisticsV2View.as_view(), name="user_statistics_v2"),
     path("api/signup-statistics/", UserSignupStatsView.as_view(), name="signup_statistics"),
 ]
 

--- a/pytest_tests/test_api.py
+++ b/pytest_tests/test_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from one_big_thing.learning import models
-from one_big_thing.learning.api_views import get_learning_breakdown_data, get_learning_breakdown_data_v2
+from one_big_thing.learning.api_views import get_learning_breakdown_data_v2
 from pytest_tests.utils import (  # noqa: F401
     TEST_USER_EMAIL,
     TEST_USER_PASSWORD,
@@ -135,7 +135,10 @@ def test_breakdown_stats(alice, bob, chris, daisy, eric):  # noqa: F811
     assert grade7["completed_first_evaluation"] == 1  # alice has done no training, bob has done the first one
     assert grade7["completed_second_evaluation"] == 0
     assert (
-        grade7["completed_1_hours_of_learning"] == 1
+        grade7["completed_0_hours_of_learning"] == 2
+    )  # alice has done 1 course of 1 hour, bob has done 1 course of one hour and one with 2
+    assert (
+        grade7["completed_1_hours_of_learning"] == 2
     )  # alice has done 1 course of 1 hour, bob has done 1 course of one hour and one with 2
     assert grade7["completed_2_hours_of_learning"] == 1  # only bob shows up here
 
@@ -143,6 +146,6 @@ def test_breakdown_stats(alice, bob, chris, daisy, eric):  # noqa: F811
     assert grade6["number_of_sign_ups"] == 3  # chris & daisy have this grade
     assert grade6["completed_first_evaluation"] == 3  # chris has completed both evaluations
     assert grade6["completed_second_evaluation"] == 2  # 1 course, 1 hour
-    assert grade6["completed_1_hours_of_learning"] == 0
+    assert grade6["completed_0_hours_of_learning"] == 1
+    assert grade6["completed_1_hours_of_learning"] == 1
     assert grade6["completed_2_hours_of_learning"] == 0
-

--- a/pytest_tests/test_api.py
+++ b/pytest_tests/test_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from one_big_thing.learning import models
-from one_big_thing.learning.api_views import get_learning_breakdown_data
+from one_big_thing.learning.api_views import get_learning_breakdown_data, get_learning_breakdown_data_v2
 from pytest_tests.utils import (  # noqa: F401
     TEST_USER_EMAIL,
     TEST_USER_PASSWORD,
@@ -110,7 +110,7 @@ def test_breakdown_stats(authenticated_api_client_fixture, add_user):  # noqa: F
     num_of_users = random.randint(0, 1200)
     for i in range(0, num_of_users):
         add_user(i)
-    url = reverse("user_statistics")
+    url = reverse("user_statistics_v2")
     response = authenticated_api_client_fixture.get(url)
     assert response.status_code == 200, response.status_code
     selected_item = None
@@ -126,7 +126,7 @@ def test_breakdown_stats(authenticated_api_client_fixture, add_user):  # noqa: F
 
 @pytest.mark.django_db
 def test_breakdown_stats(alice, bob, chris, daisy, eric):  # noqa: F811
-    learning_breakdown_data = list(get_learning_breakdown_data())
+    learning_breakdown_data = list(get_learning_breakdown_data_v2())
 
     assert len(learning_breakdown_data) == 2
 
@@ -145,3 +145,4 @@ def test_breakdown_stats(alice, bob, chris, daisy, eric):  # noqa: F811
     assert grade6["completed_second_evaluation"] == 2  # 1 course, 1 hour
     assert grade6["completed_1_hours_of_learning"] == 0
     assert grade6["completed_2_hours_of_learning"] == 0
+


### PR DESCRIPTION
I have added a new endpoint `api/v2/user-statistics/` where:
1. a new `completed_0_hours_of_learning` field has been added to capture users who have done up to 1 hours learning
2. the bucketing has been changed to be `>=` so that a user who has done exactly 1 hours learning appears in the `completed_1_hours_of_learning` bucket and not `completed_0_hours_of_learning` [bb73c23](https://github.com/i-dot-ai/one-big-thing/pull/260/commits/bb73c23e50e337dfe495cb68e0f1c639a7f420f7)