### PR TITLE
Fix so Plausable can track

### DIFF
--- a/one_big_thing/templates/macros.html
+++ b/one_big_thing/templates/macros.html
@@ -100,12 +100,12 @@
   {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <form method="post" action="{{request.path}}" novalidate>
+      <form method="post" class="{{ event_name and ("plausible-event-name=" + event_name) or ""}}" action="{{request.path}}" novalidate>
         {{csrf_input}}
 
         {{caller()}}
 
-        <button class="govuk-button {{ event_name and ("plausible-event-name=" + event_name) or ""}}"  data-module="govuk-button">
+        <button class="govuk-button"  data-module="govuk-button">
           {{button_label}}
         </button>
       </form>


### PR DESCRIPTION
I had failed to note the below in the plausible documentation:

"When tracking form submits, it is important to tag the <form> element itself with the plausible-event-name=... class (not the input or button element inside the form). Normally, Plausible can track button clicks, but if a button is inside a form, it will navigate to the next page often leaving not enough time for the event to finish.

"

https://plausible.io/docs/custom-event-goals