### PR TITLE
Bugfix/Return correct survey data in the Survey data API

### DIFF
--- a/one_big_thing/api_serializers.py
+++ b/one_big_thing/api_serializers.py
@@ -141,8 +141,8 @@ class SurveyParticipantSerializer(serializers.Serializer):
 
         for survey_type, survey_keys in SURVEY_FIELDS.items():
             condensed_survey = dict.fromkeys(survey_keys, "")
-            for survey in instance.surveyresult_set.filter(survey_type=survey_type).all().values():
-                condensed_survey = condensed_survey | survey["data"]
+            for survey in instance.surveyresult_set.filter(survey_type=survey_type).order_by("created_at"):
+                condensed_survey = condensed_survey | survey.data
             representation[survey_type] = condensed_survey
 
         return representation

--- a/one_big_thing/api_serializers.py
+++ b/one_big_thing/api_serializers.py
@@ -83,11 +83,11 @@ class LearningSerializer(serializers.Serializer):
 
 def build_empty_survey_dict(*keys: str) -> dict[str, str]:
     empty_dict = {}
-    for key, questions_level_0 in questions_data.items():
+    for key, questions_set in questions_data.items():
         if key in keys:
-            for questions_level_1 in questions_level_0:
-                for questions_level_2 in questions_level_1["questions"]:
-                    empty_dict[questions_level_2["id"]] = ""
+            for questions in questions_set:
+                for question in questions["questions"]:
+                    empty_dict[question["id"]] = ""
     return empty_dict
 
 

--- a/one_big_thing/api_serializers.py
+++ b/one_big_thing/api_serializers.py
@@ -142,7 +142,7 @@ class SurveyParticipantSerializer(serializers.Serializer):
         for survey_type, survey_keys in SURVEY_FIELDS.items():
             condensed_survey = dict.fromkeys(survey_keys, "")
             for survey in instance.surveyresult_set.filter(survey_type=survey_type).all().values():
-                condensed_survey = condensed_survey | survey['data']
+                condensed_survey = condensed_survey | survey["data"]
             representation[survey_type] = condensed_survey
 
         return representation

--- a/one_big_thing/api_serializers.py
+++ b/one_big_thing/api_serializers.py
@@ -140,9 +140,9 @@ class SurveyParticipantSerializer(serializers.Serializer):
         representation = super().to_representation(instance)
 
         for survey_type, survey_keys in SURVEY_FIELDS.items():
-            if survey := instance.surveyresult_set.filter(survey_type=survey_type).last():
-                representation[survey_type] = {
-                    survey_key: survey.data.get(survey_key, "") for survey_key in survey_keys
-                }
+            condensed_survey = dict.fromkeys(survey_keys, "")
+            for survey in instance.surveyresult_set.filter(survey_type=survey_type).all().values():
+                condensed_survey = condensed_survey | survey['data']
+            representation[survey_type] = condensed_survey
 
         return representation

--- a/one_big_thing/learning/api_views.py
+++ b/one_big_thing/learning/api_views.py
@@ -284,8 +284,6 @@ class SurveyView(ListAPIView):
         IsAPIUser,
     )
 
-    queryset = User.objects.filter(
-        surveyresult__data__contains={"willing-to-follow-up": "yes"},
-    ).order_by("id")
+    queryset = User.objects.filter(surveyresult__isnull=False).distinct().order_by('id')
     serializer_class = SurveyParticipantSerializer
     pagination_class = CustomPagination

--- a/one_big_thing/learning/api_views.py
+++ b/one_big_thing/learning/api_views.py
@@ -284,6 +284,6 @@ class SurveyView(ListAPIView):
         IsAPIUser,
     )
 
-    queryset = User.objects.filter(surveyresult__isnull=False).distinct().order_by('id')
+    queryset = User.objects.filter(surveyresult__isnull=False).distinct().order_by("id")
     serializer_class = SurveyParticipantSerializer
     pagination_class = CustomPagination

--- a/one_big_thing/learning/constants.py
+++ b/one_big_thing/learning/constants.py
@@ -96,3 +96,12 @@ BUSINESS_SPECIFIC_WORDS = [
     "cabinet office",
     "downing street",
 ]
+
+
+SURVEY_TYPES = {
+    "pre": "pre",
+    "working": "post",
+    "awareness": "post",
+    "practitioner": "post",
+    "unknown": "post",
+}

--- a/one_big_thing/learning/constants.py
+++ b/one_big_thing/learning/constants.py
@@ -104,4 +104,5 @@ SURVEY_TYPES = {
     "awareness": "post",
     "practitioner": "post",
     "unknown": "post",
+    "post": "post",
 }

--- a/one_big_thing/learning/models.py
+++ b/one_big_thing/learning/models.py
@@ -16,6 +16,9 @@ from one_big_thing.learning.survey_handling import survey_completion_map
 
 logger = logging.getLogger(__name__)
 
+POST_SURVEY_TYPES = ["post"] + [key for key, value in survey_completion_map.items() if value == "post"]
+PRE_SURVEY_TYPES = [key for key, value in survey_completion_map.items() if value == "pre"]
+
 
 class UUIDPrimaryKeyBase(models.Model):
     class Meta:
@@ -177,14 +180,11 @@ class User(BaseUser, UUIDPrimaryKeyBase):
 
     @property
     def pre_survey_results(self):
-        pre_surveys = [key for key, value in survey_completion_map.items() if value == "pre"]
-        return self.surveyresult_set.filter(survey_type__in=pre_surveys).all()
-
+        return self.surveyresult_set.filter(survey_type__in=PRE_SURVEY_TYPES).order_by("created_at")
 
     @property
     def post_survey_results(self):
-        post_surveys = [key for key, value in survey_completion_map.items() if value == "post"]
-        return self.surveyresult_set.filter(survey_type__in=post_surveys).all()
+        return self.surveyresult_set.filter(survey_type__in=POST_SURVEY_TYPES).order_by("created_at")
 
     @property
     def email_domain(self) -> str:

--- a/one_big_thing/learning/models.py
+++ b/one_big_thing/learning/models.py
@@ -12,12 +12,12 @@ from django_use_email_as_username.models import BaseUser, BaseUserManager
 
 from one_big_thing.learning import choices, constants
 from one_big_thing.learning.choices import Grade, Profession
-from one_big_thing.learning.survey_handling import survey_completion_map
+from one_big_thing.learning.constants import SURVEY_TYPES
 
 logger = logging.getLogger(__name__)
 
-POST_SURVEY_TYPES = ["post"] + [key for key, value in survey_completion_map.items() if value == "post"]
-PRE_SURVEY_TYPES = [key for key, value in survey_completion_map.items() if value == "pre"]
+POST_SURVEY_TYPES = ["post"] + [key for key, value in SURVEY_TYPES.items() if value == "post"]
+PRE_SURVEY_TYPES = [key for key, value in SURVEY_TYPES.items() if value == "pre"]
 
 
 class UUIDPrimaryKeyBase(models.Model):

--- a/one_big_thing/learning/models.py
+++ b/one_big_thing/learning/models.py
@@ -16,7 +16,7 @@ from one_big_thing.learning.constants import SURVEY_TYPES
 
 logger = logging.getLogger(__name__)
 
-POST_SURVEY_TYPES = ["post"] + [key for key, value in SURVEY_TYPES.items() if value == "post"]
+POST_SURVEY_TYPES = [key for key, value in SURVEY_TYPES.items() if value == "post"]
 PRE_SURVEY_TYPES = [key for key, value in SURVEY_TYPES.items() if value == "pre"]
 
 

--- a/one_big_thing/learning/models.py
+++ b/one_big_thing/learning/models.py
@@ -12,6 +12,7 @@ from django_use_email_as_username.models import BaseUser, BaseUserManager
 
 from one_big_thing.learning import choices, constants
 from one_big_thing.learning.choices import Grade, Profession
+from one_big_thing.learning.survey_handling import survey_completion_map
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +174,17 @@ class User(BaseUser, UUIDPrimaryKeyBase):
     has_completed_pre_survey = models.BooleanField(default=False)
     has_completed_post_survey = models.BooleanField(default=False)
     is_api_user = models.BooleanField(default=False, null=True, blank=True)
+
+    @property
+    def pre_survey_results(self):
+        pre_surveys = [key for key, value in survey_completion_map.items() if value == "pre"]
+        return self.surveyresult_set.filter(survey_type__in=pre_surveys).all()
+
+
+    @property
+    def post_survey_results(self):
+        post_surveys = [key for key, value in survey_completion_map.items() if value == "post"]
+        return self.surveyresult_set.filter(survey_type__in=post_surveys).all()
 
     @property
     def email_domain(self) -> str:

--- a/one_big_thing/learning/survey_handling.py
+++ b/one_big_thing/learning/survey_handling.py
@@ -572,10 +572,3 @@ answer_labels = {
 }
 
 
-survey_completion_map = {
-    "pre": "pre",
-    "working": "post",
-    "awareness": "post",
-    "practitioner": "post",
-    "unknown": "post",
-}

--- a/one_big_thing/learning/survey_handling.py
+++ b/one_big_thing/learning/survey_handling.py
@@ -544,20 +544,6 @@ questions_data = {
     "unknown": unknown_level_questions_data,
 }
 
-# pre_questions = tuple(q for section in pre_questions_data for q in section["questions"])
-# post_questions = tuple(q for section in post_questions_data for q in section["questions"])
-# all_questions = pre_questions + post_questions
-# section_pre_questions_map = {
-#     section["title"]: tuple(question["id"] for question in section["questions"]) for section in pre_questions_data
-# }
-# section_post_questions_map = {
-#     section["title"]: tuple(question["id"] for question in section["questions"]) for section in post_questions_data
-# }
-# section_all_questions_map = {
-#     **section_pre_questions_map,
-#     **section_post_questions_map,
-# }
-
 
 answer_labels = {
     "agree-1-5": {
@@ -584,13 +570,6 @@ answer_labels = {
     "useful-learning-formats": choices.CourseType.mapping,
     "willing-to-follow-up": dict(_yes_no),
 }
-
-
-# agree_pre_questions = tuple(item["id"] for item in pre_questions if item["answer_type"] == "agree-1-5")
-# agree_post_questions = tuple(item["id"] for item in post_questions if item["answer_type"] == "agree-1-5")
-# pre_question_sections = tuple(item["title"] for item in pre_questions_data)
-# post_question_sections = tuple(item["title"] for item in post_questions_data)
-# all_question_sections = pre_question_sections + post_question_sections
 
 
 survey_completion_map = {

--- a/one_big_thing/learning/survey_handling.py
+++ b/one_big_thing/learning/survey_handling.py
@@ -543,19 +543,19 @@ questions_data = {
     "unknown": unknown_level_questions_data,
 }
 
-pre_questions = tuple(q for section in pre_questions_data for q in section["questions"])
-post_questions = tuple(q for section in post_questions_data for q in section["questions"])
-all_questions = pre_questions + post_questions
-section_pre_questions_map = {
-    section["title"]: tuple(question["id"] for question in section["questions"]) for section in pre_questions_data
-}
-section_post_questions_map = {
-    section["title"]: tuple(question["id"] for question in section["questions"]) for section in post_questions_data
-}
-section_all_questions_map = {
-    **section_pre_questions_map,
-    **section_post_questions_map,
-}
+# pre_questions = tuple(q for section in pre_questions_data for q in section["questions"])
+# post_questions = tuple(q for section in post_questions_data for q in section["questions"])
+# all_questions = pre_questions + post_questions
+# section_pre_questions_map = {
+#     section["title"]: tuple(question["id"] for question in section["questions"]) for section in pre_questions_data
+# }
+# section_post_questions_map = {
+#     section["title"]: tuple(question["id"] for question in section["questions"]) for section in post_questions_data
+# }
+# section_all_questions_map = {
+#     **section_pre_questions_map,
+#     **section_post_questions_map,
+# }
 
 
 answer_labels = {
@@ -585,11 +585,11 @@ answer_labels = {
 }
 
 
-agree_pre_questions = tuple(item["id"] for item in pre_questions if item["answer_type"] == "agree-1-5")
-agree_post_questions = tuple(item["id"] for item in post_questions if item["answer_type"] == "agree-1-5")
-pre_question_sections = tuple(item["title"] for item in pre_questions_data)
-post_question_sections = tuple(item["title"] for item in post_questions_data)
-all_question_sections = pre_question_sections + post_question_sections
+# agree_pre_questions = tuple(item["id"] for item in pre_questions if item["answer_type"] == "agree-1-5")
+# agree_post_questions = tuple(item["id"] for item in post_questions if item["answer_type"] == "agree-1-5")
+# pre_question_sections = tuple(item["title"] for item in pre_questions_data)
+# post_question_sections = tuple(item["title"] for item in post_questions_data)
+# all_question_sections = pre_question_sections + post_question_sections
 
 
 survey_completion_map = {

--- a/one_big_thing/learning/survey_handling.py
+++ b/one_big_thing/learning/survey_handling.py
@@ -2,6 +2,7 @@ from one_big_thing.learning import choices, constants
 
 # Question IDs unique up to section (pre/post etc.)
 
+
 pre_questions_data = [
     {
         "title": "How would you feel about making a decision based on information you're presented with? This might be numerical data like statistics or non-numerical data like user feedback.",  # noqa: E501

--- a/one_big_thing/learning/survey_handling.py
+++ b/one_big_thing/learning/survey_handling.py
@@ -570,5 +570,3 @@ answer_labels = {
     "useful-learning-formats": choices.CourseType.mapping,
     "willing-to-follow-up": dict(_yes_no),
 }
-
-

--- a/one_big_thing/learning/views.py
+++ b/one_big_thing/learning/views.py
@@ -293,7 +293,12 @@ def questions_view_post(request, survey_type, page_number, errors=frozendict()):
             if completed_post_survey:
                 completed_level = completed_post_survey.data["training-level"]
                 return redirect("questions", completed_level)
-        setattr(request.user, f"has_completed_{SURVEY_TYPES[survey_type]}_survey", True)
+
+        if SURVEY_TYPES[survey_type] == "pre":
+            request.user.has_completed_pre_survey = True
+        elif SURVEY_TYPES[survey_type] == "post":
+            request.user.has_completed_post_survey = True
+
         request.user.save()
         if survey_type == "pre":
             return redirect("end-pre-survey")

--- a/one_big_thing/learning/views.py
+++ b/one_big_thing/learning/views.py
@@ -21,6 +21,7 @@ from . import (
     utils,
 )
 from .additional_learning import additional_learning
+from .constants import SURVEY_TYPES
 from .decorators import (
     enforce_user_completes_details_and_pre_survey,
     login_required,
@@ -292,7 +293,7 @@ def questions_view_post(request, survey_type, page_number, errors=frozendict()):
             if completed_post_survey:
                 completed_level = completed_post_survey.data["training-level"]
                 return redirect("questions", completed_level)
-        setattr(request.user, f"has_completed_{survey_handling.survey_completion_map[survey_type]}_survey", True)
+        setattr(request.user, f"has_completed_{SURVEY_TYPES[survey_type]}_survey", True)
         request.user.save()
         if survey_type == "pre":
             return redirect("end-pre-survey")

--- a/pytest_tests/conftest.py
+++ b/pytest_tests/conftest.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 
 import pytest
 import pytz
+from django.core.management import call_command
 
 from one_big_thing.learning.models import (
     Department,
@@ -12,6 +13,11 @@ from one_big_thing.learning.models import (
 )
 
 UTC = pytz.timezone("UTC")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def collect_static():
+    call_command("collectstatic", "--noinput")
 
 
 @pytest.fixture

--- a/pytest_tests/test_api.py
+++ b/pytest_tests/test_api.py
@@ -214,7 +214,8 @@ def test_select_surveys(create_user, authenticated_api_client_fixture):
         page_number=1,
     )
 
-    user_without_survey = create_user(
+    # a user without a survey
+    _ = create_user(
         email="alex@example.com",
         date_joined="2000-01-02",
         grade="GRADE7",
@@ -229,7 +230,7 @@ def test_select_surveys(create_user, authenticated_api_client_fixture):
 
     assert len(response.json()["results"]) == 2
 
-    returned_grades = [x['grade'] for x in response.json()['results']]
-    assert 'EXECUTIVE_OFFICER' in returned_grades
-    assert 'GRADE6' in returned_grades
-    assert 'GRADE7' not in returned_grades
+    returned_grades = [x["grade"] for x in response.json()["results"]]
+    assert "EXECUTIVE_OFFICER" in returned_grades
+    assert "GRADE6" in returned_grades
+    assert "GRADE7" not in returned_grades

--- a/pytest_tests/test_api.py
+++ b/pytest_tests/test_api.py
@@ -174,20 +174,62 @@ def test_get_department_stats(authenticated_api_client_fixture, alice, bob, chri
 
 
 @pytest.mark.django_db
-def test_get_surveys(
-    authenticated_api_client_fixture, alice, bob, chris, daisy, eric, pre_survey_data, post_survey_data
-):  # noqa: F811
+def test_select_surveys(create_user, authenticated_api_client_fixture):
+    user_with_survey = create_user(
+        email="chris@example.com",
+        date_joined="2000-01-02",
+        grade="GRADE6",
+        times_to_complete=[60],
+        has_completed_pre_survey=True,
+        has_completed_post_survey=True,
+    )
+
+    models.SurveyResult.objects.create(
+        user=user_with_survey,
+        data={"confident-in-decisions": "very-confident"},
+        survey_type="pre",
+        page_number=1,
+    )
+
+    user_with_multiple_surveys = create_user(
+        email="dsfjkds@example.com",
+        date_joined="2000-01-02",
+        grade="EXECUTIVE_OFFICER",
+        times_to_complete=[60],
+        has_completed_pre_survey=True,
+        has_completed_post_survey=True,
+    )
+
+    models.SurveyResult.objects.create(
+        user=user_with_multiple_surveys,
+        data={"confident-in-decisions": "very-confident"},
+        survey_type="pre",
+        page_number=1,
+    )
+
+    models.SurveyResult.objects.create(
+        user=user_with_multiple_surveys,
+        data={"confident-in-decisions": "very-confident"},
+        survey_type="post",
+        page_number=1,
+    )
+
+    user_without_survey = create_user(
+        email="alex@example.com",
+        date_joined="2000-01-02",
+        grade="GRADE7",
+        times_to_complete=[60],
+        has_completed_pre_survey=True,
+        has_completed_post_survey=True,
+    )
+
     url = reverse("surveys")
     response = authenticated_api_client_fixture.get(url)
     assert response.status_code == 200, response.status_code
 
-    g6 = next(x for x in response.json()["results"] if x["grade"] == "GRADE6")
-    g7 = next(x for x in response.json()["results"] if x["grade"] == "GRADE7")
+    assert len(response.json()["results"]) == 2
 
-    assert len(g6["learning_records"]) == 1
-    assert len(g7["learning_records"]) == 2
-
-    assert "pre" in g6
-    assert "pre" in g7
-    assert "post" not in g6
-    assert "post" in g7
+    returned_grades = [x['grade'] for x in response.json()['results']]
+    assert 'EXECUTIVE_OFFICER' in returned_grades
+    assert 'GRADE6' in returned_grades
+    assert 'GRADE7' not in returned_grades

--- a/pytest_tests/test_models.py
+++ b/pytest_tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 
 from one_big_thing.learning import models
-from one_big_thing.learning.models import Department
+from one_big_thing.learning.models import Department, SurveyResult
 
 
 @pytest.mark.django_db
@@ -31,6 +31,42 @@ def test_user_save():
     new_user2, _ = models.User.objects.update_or_create(email=new_email2)
     assert new_user1.email == "new_user1@example.org", new_user1.email
     assert new_user2.email == "new_user2@example.com", new_user2.email
+
+
+@pytest.mark.django_db
+def test_survey_results(create_user):
+    alice = create_user(email="alice@example.com")
+    SurveyResult.objects.create(
+        user=alice,
+        survey_type="pre",
+        page_number=1,
+    )
+    SurveyResult.objects.create(
+        user=alice,
+        survey_type="pre",
+        page_number=2,
+    )
+    SurveyResult.objects.create(
+        user=alice,
+        survey_type="post",
+        page_number=3,
+    )
+    SurveyResult.objects.create(
+        user=alice,
+        survey_type="working",
+        page_number=4,
+    )
+    SurveyResult.objects.create(
+        user=alice,
+        survey_type="practitioner",
+        page_number=5,
+    )
+
+    assert len(alice.pre_survey_results) == 2
+    assert [result.page_number for result in alice.pre_survey_results] == [1, 2]
+
+    assert len(alice.post_survey_results) == 3
+    assert [result.page_number for result in alice.post_survey_results] == [3, 4, 5]
 
 
 def test_determine_competency_levels():

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -1,0 +1,117 @@
+import pytest
+
+from one_big_thing.api_serializers import SurveyParticipantSerializer
+from one_big_thing.learning.models import SurveyResult
+
+
+@pytest.mark.django_db
+def test_serialize_user(create_user):
+    user = create_user(
+        email="chris@co.gov.uk",
+        date_joined="2000-01-02",
+        grade="GRADE6",
+        times_to_complete=[60],
+        has_completed_pre_survey=True,
+        has_completed_post_survey=True,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"confident-in-decisions": "very-confident"},
+        survey_type="pre",
+        page_number=1,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"training-level": "practitioner"},
+        survey_type="post",
+        page_number=1,
+    )
+    serializer = SurveyParticipantSerializer(instance=user)
+
+    output = serializer.to_representation(user)
+
+    assert output["pre"]["confident-in-decisions"] == "very-confident"
+    assert output["post"]["training-level"] == "practitioner"
+
+    for k, v in output["pre"].items():
+        if k != "confident-in-decisions":
+            assert v == ""
+
+    for k, v in output["post"].items():
+        if k != "training-level":
+            assert v == ""
+
+
+@pytest.mark.django_db
+def test_serialize_user_with_multiple_surveys(create_user):
+    user = create_user(
+        email="chris@co.gov.uk",
+        date_joined="2000-01-02",
+        grade="GRADE6",
+        times_to_complete=[60],
+        has_completed_pre_survey=True,
+        has_completed_post_survey=True,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"confident-in-decisions": "very-confident"},
+        survey_type="pre",
+        page_number=1,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"help-team": "no"},
+        survey_type="pre",
+        page_number=1,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"training-level": "practitioner"},
+        survey_type="post",
+        page_number=1,
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={"aware-of-aims": "yes"},
+        survey_type="post",
+        page_number=1,
+    )
+
+    serializer = SurveyParticipantSerializer(instance=user)
+
+    output = serializer.to_representation(user)
+
+    assert output["pre"]["confident-in-decisions"] == "very-confident"
+    assert output["pre"]["help-team"] == "no"
+    assert output["post"]["training-level"] == "practitioner"
+    assert output["post"]["aware-of-aims"] == "yes"
+
+
+@pytest.mark.django_db
+def test_serialize_user_without_surveys(create_user):
+    # we don't expect this to be required in practice, but good
+    # to know it won't fall over
+    user = create_user(
+        email="chris@co.gov.uk",
+        date_joined="2000-01-02",
+        grade="GRADE6",
+        times_to_complete=[60],
+        has_completed_pre_survey=False,
+        has_completed_post_survey=False,
+    )
+
+    serializer = SurveyParticipantSerializer(instance=user)
+
+    output = serializer.to_representation(user)
+
+    for k, v in output["pre"].items():
+        assert v == ""
+
+    for k, v in output["post"].items():
+        assert v == ""

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -40,8 +40,8 @@ def test_serialize_user(create_user):
 
     output = serializer.to_representation(user)
 
-    assert all(v == "very-confident" if k == "confident-in-decisions" else "" for k, v in output["pre"].items())
-    assert all(v == "practitioner" if k == "training-level" else "" for k, v in output["post"].items())
+    assert all(v == ("very-confident" if k == "confident-in-decisions" else "") for k, v in output["pre"].items())
+    assert all(v == ("practitioner" if k == "training-level" else "") for k, v in output["post"].items())
 
 
 @pytest.mark.django_db

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -40,16 +40,8 @@ def test_serialize_user(create_user):
 
     output = serializer.to_representation(user)
 
-    assert output["pre"]["confident-in-decisions"] == "very-confident"
-    assert output["post"]["training-level"] == "practitioner"
-
-    for k, v in output["pre"].items():
-        if k != "confident-in-decisions":
-            assert v == ""
-
-    for k, v in output["post"].items():
-        if k != "training-level":
-            assert v == ""
+    assert all(v == "very-confident" if k == "confident-in-decisions" else "" for k, v in output["pre"].items())
+    assert all(v == "practitioner" if k == "training-level" else "" for k, v in output["post"].items())
 
 
 @pytest.mark.django_db

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -175,6 +175,10 @@ ALL_QUESTIONS = (
 @pytest.mark.parametrize("survey_type, survey_sub_type, question", ALL_QUESTIONS)
 @pytest.mark.django_db
 def test_serialize_user_all_question_fields(create_user, survey_type, survey_sub_type, question):
+    """For each question, we create a survey result with the type (pre/post) and sub-type (other)
+    and the question, and assign the answer 'yes'.
+    We then asserts that the output has the question and answer are correctly assigned
+    """
     user = create_user(
         email="chris@co.gov.uk",
         date_joined="2000-01-02",

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -158,8 +158,8 @@ def test_serialize_user_with_overrides(create_user):
     assert output["pre"]["help-team"] == "no"
 
 
-def _build_questions(survey_type, survey_sub_type, question):
-    return [(survey_type, survey_sub_type, q["id"]) for d in question for q in d["questions"]]
+def _build_questions(survey_type_group, survey_type, question):
+    return [(survey_type_group, survey_type, q["id"]) for d in question for q in d["questions"]]
 
 
 ALL_QUESTIONS = (
@@ -174,8 +174,8 @@ ALL_QUESTIONS = (
 
 @pytest.mark.parametrize("survey_type, survey_sub_type, question", ALL_QUESTIONS)
 @pytest.mark.django_db
-def test_serialize_user_all_question_fields(create_user, survey_type, survey_sub_type, question):
-    """For each question, we create a survey result with the type (pre/post) and sub-type (other)
+def test_serialize_user_all_question_fields(create_user, survey_type_group, survey_type, question):
+    """For each question, we create a survey result with the survey-type-group (pre/post) and survey-type (other)
     and the question, and assign the answer 'yes'.
     We then asserts that the output has the question and answer are correctly assigned
     """
@@ -189,7 +189,7 @@ def test_serialize_user_all_question_fields(create_user, survey_type, survey_sub
     SurveyResult.objects.create(
         user=user,
         data={question: "yes"},
-        survey_type=survey_sub_type,
+        survey_type=survey_type,
         page_number=1,
     )
 
@@ -197,4 +197,4 @@ def test_serialize_user_all_question_fields(create_user, survey_type, survey_sub
 
     output = serializer.to_representation(user)
 
-    assert output[survey_type][question] == "yes"
+    assert output[survey_type_group][question] == "yes"

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -172,7 +172,7 @@ ALL_QUESTIONS = (
 )
 
 
-@pytest.mark.parametrize("survey_type, survey_sub_type, question", ALL_QUESTIONS)
+@pytest.mark.parametrize("survey_type_group, survey_type, question", ALL_QUESTIONS)
 @pytest.mark.django_db
 def test_serialize_user_all_question_fields(create_user, survey_type_group, survey_type, question):
     """For each question, we create a survey result with the survey-type-group (pre/post) and survey-type (other)

--- a/pytest_tests/test_serializers.py
+++ b/pytest_tests/test_serializers.py
@@ -2,6 +2,14 @@ import pytest
 
 from one_big_thing.api_serializers import SurveyParticipantSerializer
 from one_big_thing.learning.models import SurveyResult
+from one_big_thing.learning.survey_handling import (
+    awareness_level_questions_data,
+    post_questions_data,
+    practitioner_level_questions_data,
+    pre_questions_data,
+    unknown_level_questions_data,
+    working_level_questions_data,
+)
 
 
 @pytest.mark.django_db
@@ -148,3 +156,41 @@ def test_serialize_user_with_overrides(create_user):
     output = serializer.to_representation(user)
 
     assert output["pre"]["help-team"] == "no"
+
+
+def _build_questions(survey_type, survey_sub_type, question):
+    return [(survey_type, survey_sub_type, q["id"]) for d in question for q in d["questions"]]
+
+
+ALL_QUESTIONS = (
+    _build_questions("pre", "pre", pre_questions_data)
+    + _build_questions("post", "post", post_questions_data)
+    + _build_questions("post", "awareness", awareness_level_questions_data)
+    + _build_questions("post", "working", working_level_questions_data)
+    + _build_questions("post", "practitioner", practitioner_level_questions_data)
+    + _build_questions("post", "unknown", unknown_level_questions_data)
+)
+
+
+@pytest.mark.parametrize("survey_type, survey_sub_type, question", ALL_QUESTIONS)
+@pytest.mark.django_db
+def test_serialize_user_all_question_fields(create_user, survey_type, survey_sub_type, question):
+    user = create_user(
+        email="chris@co.gov.uk",
+        date_joined="2000-01-02",
+        grade="GRADE6",
+        times_to_complete=[60],
+    )
+
+    SurveyResult.objects.create(
+        user=user,
+        data={question: "yes"},
+        survey_type=survey_sub_type,
+        page_number=1,
+    )
+
+    serializer = SurveyParticipantSerializer(instance=user)
+
+    output = serializer.to_representation(user)
+
+    assert output[survey_type][question] == "yes"

--- a/pytest_tests/test_views.py
+++ b/pytest_tests/test_views.py
@@ -21,6 +21,8 @@ import pytest
             "/questions/awareness/2/",
         ),
         ("awareness", 8, {"willing-to-follow-up": "yes"}, False, True, "/end-post-survey/"),
+        ("post", 1, {"training-level": "yes"}, False, False, "/questions/post/2/"),
+        ("post", 5, {"willing-to-follow-up": "yes"}, False, True, "/home/"),
     ],
 )
 @pytest.mark.django_db

--- a/pytest_tests/test_views.py
+++ b/pytest_tests/test_views.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "survey_type, page_number, payload, expected_has_completed_pre_survey, expected_has_completed_post_survey, expected_redirect",
+    "survey_type, page_number, payload, expected_has_completed_pre_survey, expected_has_completed_post_survey, expected_redirect",  # noqa
     [
         ("pre", 1, {"confident-in-decisions": "very-confident"}, False, False, "/questions/pre/2/"),
         ("pre", 9, {"shared-identity": "1", "identity-is-important": "2"}, True, False, "/end-pre-survey/"),

--- a/pytest_tests/test_views.py
+++ b/pytest_tests/test_views.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "survey_type, page_number, payload, expected_has_completed_pre_survey, expected_has_completed_post_survey, expected_redirect",
+    [
+        ("pre", 1, {"confident-in-decisions": "very-confident"}, False, False, "/questions/pre/2/"),
+        ("pre", 9, {"shared-identity": "1", "identity-is-important": "2"}, True, False, "/end-pre-survey/"),
+        (
+            "awareness",
+            1,
+            {
+                "i-understand-what-data-means": "1",
+                "better-at-interpreting-data": "2",
+                "interested-in-working-with-data-in-day-to-day": "3",
+                "more-confident-using-data-for-decisions": "4",
+                "more-confident-communicating-data-to-influence-decisions": "4",
+            },
+            False,
+            False,
+            "/questions/awareness/2/",
+        ),
+        ("awareness", 8, {"willing-to-follow-up": "yes"}, False, True, "/end-post-survey/"),
+    ],
+)
+@pytest.mark.django_db
+def test_questions_view(
+    create_user,
+    client,
+    survey_type,
+    page_number,
+    payload,
+    expected_has_completed_pre_survey,
+    expected_has_completed_post_survey,
+    expected_redirect,
+):
+    user = create_user(email="someone@example.com")
+    client.force_login(user)
+    url = f"/questions/{survey_type}/{page_number}/"
+    response = client.post(url, data=payload)
+
+    user.refresh_from_db()
+    assert user.has_completed_pre_survey == expected_has_completed_pre_survey
+    assert user.has_completed_post_survey == expected_has_completed_post_survey
+    assert response.status_code == 302
+    assert response.url == expected_redirect


### PR DESCRIPTION
## Context

ETF pointed out that the data in the API was a) incomplete within each record and b) it had fewer records than they expected.

## Changes proposed in this Pull Request

- add tests for the `SurveyParticipantSerializer`
- change the behaviour to progressively merge a user's surveys of each type into a single dict, instead of looking only at the final survey
- change the selection criteria for `User`s to return from "willing-to-follow-up" to the presence of a survey

## Guidance to review

Do the tests cover all cases? We looked at surveyless users, users with multiple surveys of the same kind, and users with only one survey of each kind.

Paired with @gecBurton 