### PR TITLE
Bugfix/Remove outdated LINK reference from add_courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run this project:
 
 open http://localhost:8055/
 
-To populate the database with fake data:
+To populate the database with fake data and provide courses essential for the app to run:
 
     docker-compose run web python manage.py add_courses
 

--- a/one_big_thing/learning/management/commands/add_courses.py
+++ b/one_big_thing/learning/management/commands/add_courses.py
@@ -7,31 +7,31 @@ courses = (
         "link": "https://learn.civilservice.gov.uk/courses/GyZgKWc0Tz6ZIfvDSiuO1Q",
         "title": "Data quality",
         "duration": "80",
-        "learning_type": choices.CourseType.LINK.name,
+        "learning_type": choices.CourseType.EVENT_CENTRAL.name,
     },
     {
         "link": "https://learn.civilservice.gov.uk/courses/2PAR3NQyT-GOg5-7bVZaog",
         "title": "Data visualisation",
         "duration": "60",
-        "learning_type": choices.CourseType.LINK.name,
+        "learning_type": choices.CourseType.EVENT_CENTRAL.name,
     },
     {
         "link": "https://learn.civilservice.gov.uk/courses/BfBwomNDSEGgpf9b16RJsg",
         "title": "Data visualisation e-learning",
         "duration": "30",
-        "learning_type": choices.CourseType.LINK.name,
+        "learning_type": choices.CourseType.EVENT_CENTRAL.name,
     },
     {
         "link": "https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g",
         "title": "Security and data protection",
         "duration": "95",
-        "learning_type": choices.CourseType.LINK.name,
+        "learning_type": choices.CourseType.EVENT_CENTRAL.name,
     },
     {
         "link": "https://learn.civilservice.gov.uk/courses/s5y7_eboT4iIuz2sUTB-CQ",
         "title": "Government security classification policy",
         "duration": "30",
-        "learning_type": choices.CourseType.LINK.name,
+        "learning_type": choices.CourseType.EVENT_CENTRAL.name,
     },
 )
 

--- a/one_big_thing/learning/management/commands/add_courses.py
+++ b/one_big_thing/learning/management/commands/add_courses.py
@@ -1,6 +1,8 @@
+from django.core import management
 from django.core.management import BaseCommand
 
 from one_big_thing.learning import choices, models
+from one_big_thing.learning.management.commands import add_special_courses
 
 courses = (
     {
@@ -36,7 +38,7 @@ courses = (
 )
 
 
-class Command(BaseCommand):
+class Command(management.BaseCommand):
     help = "Add fake courses"
 
     def handle(self, *args, **kwargs):
@@ -47,3 +49,6 @@ class Command(BaseCommand):
             new_course.time_to_complete = course["duration"]
             new_course.learning_type = course["learning_type"]
             new_course.save()
+
+        # the app needs special_courses to work correctly
+        management.call_command(add_special_courses.Command())

--- a/one_big_thing/learning/management/commands/add_courses.py
+++ b/one_big_thing/learning/management/commands/add_courses.py
@@ -1,5 +1,4 @@
 from django.core import management
-from django.core.management import BaseCommand
 
 from one_big_thing.learning import choices, models
 from one_big_thing.learning.management.commands import add_special_courses


### PR DESCRIPTION
## Context

`add_courses`, which is used to create dummy course data, fails like this:

```
File "/Users/duncan.brown/projects/i-dot-ai/one-big-thing/one_big_thing/learning/management/commands/add_courses.py", line 10, in <module>
    "learning_type": choices.CourseType.LINK.name,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/enum.py", line 429, in __getattr__
    raise AttributeError(name) from None
AttributeError: LINK
```

## Changes proposed in this pull request

Use an enum value for this dummy data that wasn't removed in 041ba2f70b32bf86a1fe!

## Guidance to review

Is this going to break anything?